### PR TITLE
Updates Thunderlord Zinogre monstie info

### DIFF
--- a/assets/data/monsters.json
+++ b/assets/data/monsters.json
@@ -5413,7 +5413,7 @@
     }
   },
   {
-    // TODO defeat, hatch
+    // TODO defeat
     "no": 117,
     "name": "Thunderlord Zinogre",
     "genus": "Fanged Wyvern",
@@ -5456,7 +5456,7 @@
     },
     "hatchable": true,
     "monstie": {
-      "attackType": "technical",
+      "attackType": "power",
       "growth": "slow",
       "ridingActions": ["Jump"],
       "kinshipSkill": "Gigavolt Crash",
@@ -5464,26 +5464,26 @@
       "retreat": "This monster **cannot** be chased back to its den.",
       "stats": {
         "base": {
-          "maxHp": null,
-          "speed": null,
-          "recovery": null,
-          "critRate": null
+          "maxHp": 8,
+          "speed": 6,
+          "recovery": 5,
+          "critRate": 9
         },
         "attack": {
-          "none": null,
-          "fire": null,
-          "water": null,
-          "thunder": null,
-          "ice": null,
-          "dragon": null
+          "none": 6,
+          "fire": 6,
+          "water": 6,
+          "thunder": 8,
+          "ice": 4,
+          "dragon": 6
         },
         "defense": {
-          "none": null,
-          "fire": null,
-          "water": null,
-          "thunder": null,
-          "ice": null,
-          "dragon": null
+          "none": 6,
+          "fire": 6,
+          "water": 6,
+          "thunder": 8,
+          "ice": 4,
+          "dragon": 6
         }
       }
     }


### PR DESCRIPTION
## About The Pull Request
This PR corrects the monstie attack type of Thunderlord Zinogre (power, not tech), and also adds its monstie stats.
I considered making an issue, but just changing a json is easy enough.

## Screenshots

<details>
<summary> values in screenshot form</summary>

type:

<img width="1000" height="185" alt="image" src="https://github.com/user-attachments/assets/e4e5d512-5aa1-4ed7-b5f2-9249c17746de" />

base stats:

<img width="518" height="359" alt="image" src="https://github.com/user-attachments/assets/3e65d453-2f3b-462a-84ba-e2a806097d7d" />

atk / def:

<img width="1011" height="430" alt="image" src="https://github.com/user-attachments/assets/afdb55d5-13a2-48d8-a11a-0dffc6c1084d" />


</details>